### PR TITLE
Add notification and battery optimization permission checks at launch

### DIFF
--- a/app-base/src/main/java/xyz/aprildown/timer/app/base/data/PreferenceData.kt
+++ b/app-base/src/main/java/xyz/aprildown/timer/app/base/data/PreferenceData.kt
@@ -445,4 +445,7 @@ object PreferenceData {
     var SharedPreferences.isTtsBakeryOpen: Boolean
         get() = getBoolean(PREF_IS_TTS_BAKERY_OPEN, AppConfig.openDebug)
         set(value) = edit { putBoolean(PREF_IS_TTS_BAKERY_OPEN, value) }
+
+    const val PREF_SUPPRESS_NOTIFICATION_CHECK = "pref_suppress_notification_permission_check"
+    const val PREF_SUPPRESS_BATTERY_CHECK = "pref_suppress_battery_optimization_check"
 }

--- a/app-base/src/main/res/values/strings.xml
+++ b/app-base/src/main/res/values/strings.xml
@@ -830,6 +830,18 @@
 
     <string name="whitelist_settings_template">System setting %d</string>
 
+    <!--Permission checks-->
+    <string name="permission_notifications_title">Enable Notifications</string>
+    <string name="permission_notifications_message">Timer Machine needs notification permission to show timer countdowns and alerts when timers expire. Without it, timers will run silently.</string>
+    <string name="permission_battery_title">Disable Battery Optimization</string>
+    <string name="permission_battery_message">Battery optimization may stop timers from running in the background. Please disable it for Timer Machine to ensure reliable timer operation.</string>
+    <string name="permission_enable">Enable</string>
+    <string name="permission_not_now">Not now</string>
+    <string name="permission_dont_ask_again">Don\'t ask again</string>
+    <string name="pref_reset_permission_reminders">Reset permission reminders</string>
+    <string name="pref_reset_permission_reminders_summary">Re-enable notification and battery optimization prompts</string>
+    <string name="pref_permission_reminders_reset">Permission reminders re-enabled</string>
+
     <!--Account-->
     <string name="account_sign_out_confirmation">Sign out?</string>
     <string name="account_sign_out">Sign Out</string>

--- a/app-settings/src/main/java/xyz/aprildown/timer/app/settings/SettingsFragment.kt
+++ b/app-settings/src/main/java/xyz/aprildown/timer/app/settings/SettingsFragment.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Build
+import androidx.core.content.edit
 import android.os.Bundle
 import android.provider.Settings
 import androidx.activity.result.contract.ActivityResultContracts
@@ -12,6 +13,7 @@ import androidx.navigation.fragment.NavHostFragment
 import androidx.preference.ListPreference
 import androidx.preference.Preference
 import com.github.deweyreed.timer.component.tts.TtsBakery
+import com.github.deweyreed.tools.anko.snackbar
 import com.github.deweyreed.tools.helper.IntentHelper
 import com.github.deweyreed.tools.helper.createChooserIntentIfDead
 import com.github.deweyreed.tools.helper.hasPermissions
@@ -171,6 +173,14 @@ class SettingsFragment :
                 NavHostFragment.findNavController(this)
                     .subLevelNavigate(RBase.id.dest_about)
             }
+            KEY_RESET_PERMISSION_REMINDERS -> {
+                sharedPreferences.edit {
+                    putBoolean(PreferenceData.PREF_SUPPRESS_NOTIFICATION_CHECK, false)
+                    putBoolean(PreferenceData.PREF_SUPPRESS_BATTERY_CHECK, false)
+                }
+                (requireActivity() as MainCallback.ActivityCallback).snackbarView
+                    .snackbar(getString(RBase.string.pref_permission_reminders_reset))
+            }
             else -> return false
         }
         return true
@@ -221,6 +231,7 @@ class SettingsFragment :
         }
 
         findPreference<Preference>(KEY_NOTIF_SETTING)?.onPreferenceClickListener = this
+        findPreference<Preference>(KEY_RESET_PERMISSION_REMINDERS)?.onPreferenceClickListener = this
 
         findPreference<Preference>(KEY_AUDIO_VOLUME)?.run {
             onPreferenceClickListener = this@SettingsFragment
@@ -330,6 +341,7 @@ private const val KEY_PHONE_CALL = PreferenceData.KEY_PHONE_CALL
 private const val KEY_WEEK_START = PreferenceData.KEY_WEEK_START
 
 private const val KEY_NOTIF_SETTING = "key_notif_setting"
+private const val KEY_RESET_PERMISSION_REMINDERS = "key_reset_permission_reminders"
 
 private const val KEY_AUDIO_VOLUME = "key_audio_volume"
 

--- a/app-settings/src/main/res/xml/pref_settings.xml
+++ b/app-settings/src/main/res/xml/pref_settings.xml
@@ -136,6 +136,14 @@
             app:key="key_media_style_notification"
             app:title="@string/pref_media_style_notification" />
 
+        <Preference
+            app:icon="@drawable/settings_notifications"
+            app:key="key_reset_permission_reminders"
+            app:persistent="false"
+            app:singleLineTitle="false"
+            app:title="@string/pref_reset_permission_reminders"
+            app:summary="@string/pref_reset_permission_reminders_summary" />
+
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/pref_category_title_audio">

--- a/app-timer-list/src/main/java/xyz/aprildown/timer/app/timer/list/TimerFragment.kt
+++ b/app-timer-list/src/main/java/xyz/aprildown/timer/app/timer/list/TimerFragment.kt
@@ -3,19 +3,25 @@ package xyz.aprildown.timer.app.timer.list
 import android.Manifest
 import android.content.ComponentName
 import android.content.Context
+import android.content.Intent
 import android.content.ServiceConnection
 import android.graphics.Typeface
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
+import android.os.PowerManager
+import android.provider.Settings
 import android.text.Spanned
 import android.text.style.StyleSpan
+import android.widget.CheckBox
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.StringRes
 import androidx.core.content.edit
+import androidx.core.net.toUri
 import androidx.core.text.buildSpannedString
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
@@ -144,16 +150,23 @@ class TimerFragment :
         }
     }
 
+    private var hasCheckedPermissionsThisResume = false
+
     override fun onResume() {
         super.onResume()
         ScreenWakeLock.acquireScreenWakeLock(
             context = requireActivity(),
             screenTiming = getString(RBase.string.pref_screen_timing_value_timer)
         )
+        if (!hasCheckedPermissionsThisResume) {
+            hasCheckedPermissionsThisResume = true
+            view?.post { checkPermissions() }
+        }
     }
 
     override fun onPause() {
         super.onPause()
+        hasCheckedPermissionsThisResume = false
         ScreenWakeLock.releaseScreenLock(
             context = requireActivity(),
             screenTiming = getString(RBase.string.pref_screen_timing_value_timer)
@@ -593,6 +606,94 @@ class TimerFragment :
                 }
             }
         }
+    }
+
+    private fun checkPermissions() {
+        val context = context ?: return
+        if (viewModel.tips.value != TipManager.TIP_NO_MORE) return
+
+        val prefs = context.safeSharedPreference
+
+        // Check notification permission (Android 13+)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            !context.hasPermissions(Manifest.permission.POST_NOTIFICATIONS)
+        ) {
+            if (!prefs.getBoolean(PreferenceData.PREF_SUPPRESS_NOTIFICATION_CHECK, false)) {
+                if (!shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
+                    postNotificationsLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                } else {
+                    showPermissionDialog(
+                        title = RBase.string.permission_notifications_title,
+                        message = RBase.string.permission_notifications_message,
+                        suppressKey = PreferenceData.PREF_SUPPRESS_NOTIFICATION_CHECK,
+                        onEnable = {
+                            startActivity(
+                                Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+                                    .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+                            )
+                        }
+                    )
+                }
+                return
+            }
+        }
+
+        // Check battery optimization
+        val pm = context.getSystemService(PowerManager::class.java)
+        if (pm != null && !pm.isIgnoringBatteryOptimizations(context.packageName)) {
+            if (!prefs.getBoolean(PreferenceData.PREF_SUPPRESS_BATTERY_CHECK, false)) {
+                showPermissionDialog(
+                    title = RBase.string.permission_battery_title,
+                    message = RBase.string.permission_battery_message,
+                    suppressKey = PreferenceData.PREF_SUPPRESS_BATTERY_CHECK,
+                    onEnable = {
+                        startActivity(
+                            @Suppress("BatteryLife")
+                            Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
+                                .setData("package:${context.packageName}".toUri())
+                        )
+                    }
+                )
+            }
+        }
+    }
+
+    private fun showPermissionDialog(
+        @StringRes title: Int,
+        @StringRes message: Int,
+        suppressKey: String,
+        onEnable: () -> Unit
+    ) {
+        val context = context ?: return
+        val checkBox = CheckBox(context).apply {
+            setText(RBase.string.permission_dont_ask_again)
+        }
+        val container = android.widget.FrameLayout(context).apply {
+            val horizontalMargin = context.dp(24).toInt()
+            addView(checkBox, android.widget.FrameLayout.LayoutParams(
+                android.widget.FrameLayout.LayoutParams.WRAP_CONTENT,
+                android.widget.FrameLayout.LayoutParams.WRAP_CONTENT
+            ).apply {
+                marginStart = horizontalMargin
+                marginEnd = horizontalMargin
+            })
+        }
+        MaterialAlertDialogBuilder(context)
+            .setTitle(title)
+            .setMessage(message)
+            .setView(container)
+            .setPositiveButton(RBase.string.permission_enable) { _, _ ->
+                if (checkBox.isChecked) {
+                    context.safeSharedPreference.edit { putBoolean(suppressKey, true) }
+                }
+                onEnable()
+            }
+            .setNegativeButton(RBase.string.permission_not_now) { _, _ ->
+                if (checkBox.isChecked) {
+                    context.safeSharedPreference.edit { putBoolean(suppressKey, true) }
+                }
+            }
+            .show()
     }
 
     private val mConnection: ServiceConnection = object : ServiceConnection {


### PR DESCRIPTION
## Summary

- Adds recurring permission checks when the app opens for notification permission (Android 13+) and battery optimization exemption
- Shows a dialog explaining why each permission is needed, with "Enable" and "Not now" buttons
- Includes a "Don't ask again" checkbox that permanently suppresses the prompt (stored in SharedPreferences)
- Adds a "Reset permission reminders" option in Settings > Notifications to re-enable suppressed prompts
- Permission checks are skipped while onboarding tips are still active, so new users complete the tutorial first
- Dialogs are shown one at a time in `onResume`, so they re-check when the user returns from system settings

**Note**: This PR is a prerequisite for a follow-up PR that adds broadcast intent support for external app control of timers (see the broadcast-intents branch). The battery optimization exemption in particular is needed for broadcast receivers to start foreground services on Android 12+.

## Test plan

- [x] Revoke notification permission on Android 13+ emulator — notification dialog appears on launch
- [x] Tap "Enable" — opens Android notification settings for the app
- [x] Grant permission, return to app — battery optimization dialog appears next
- [x] Tap "Enable" on battery dialog — system battery optimization prompt appears
- [x] Grant exemption, return to app — no more dialogs
- [x] Revoke permission again, check "Don't ask again" + tap "Not now" — dialog does not reappear
- [x] Go to Settings > Notifications > "Reset permission reminders" — snackbar confirms reset
- [x] Reopen app — suppressed dialogs reappear
- [x] Fresh install — verify onboarding tips show first, permission dialogs only appear after onboarding completes
- [x] Run `./gradlew test` — no regressions
- [x] Test all of the above on an actual device (tested on Pixel 10 Pro Fold). 